### PR TITLE
Minor improvements

### DIFF
--- a/generate_act_scale_shift.py
+++ b/generate_act_scale_shift.py
@@ -97,7 +97,7 @@ def get_act_shifts(model, dataloader, num_samples=128):
 
 
 def build_model_and_tokenizer(model_name):
-    kwargs = {"torch_dtype": torch.float16, "device_map": "sequential"}
+    kwargs = {"torch_dtype": torch.float16, "device_map": "auto"}
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     model = AutoModelForCausalLM.from_pretrained(model_name, **kwargs)
     return model, tokenizer

--- a/parallel_utils.py
+++ b/parallel_utils.py
@@ -42,7 +42,12 @@ num_gpus = torch.cuda.device_count()
 def get_gpu_memory():
     memory_info = []
     gpu_memory_info = nvidia_smi_memory_info()
-    gpu_index = [int(k) for k in os.environ['CUDA_VISIBLE_DEVICES'].split(',')]
+
+    try:
+        gpu_index = [int(k) for k in os.environ['CUDA_VISIBLE_DEVICES'].split(',')]
+    except KeyError:
+        gpu_index = [x["id"] for x in gpu_memory_info]
+
     for gpu_id, i in enumerate( gpu_index):
         gpu = gpu_memory_info[i]
         total_memory = gpu["total_memory"]


### PR DESCRIPTION
1. Allow using multiple GPUs in `generate_act_scale_shift.py`
2. Allow quantizing models that have the same architectures as supported models but different model names with the `--net` command line argument.
3. Allow using differently named activation shifts and scales files with the `--act-scales` and `--act-shifts` command line arguments.