### PR TITLE
Fix ChatModule initalization with model_lib_path argument

### DIFF
--- a/runing_quantized_models_with_mlc_llm.ipynb
+++ b/runing_quantized_models_with_mlc_llm.ipynb
@@ -127,7 +127,7 @@
         "from mlc_chat import ChatModule\n",
         "from mlc_chat.callback import StreamToStdout\n",
         "\n",
-        "cm = ChatModule(model=\"dist/Llama-2-7b-chat-omniquant-w3a16g128asym/params\", lib_path=\"dist/Llama-2-7b-chat-omniquant-w3a16g128asym/Llama-2-7b-chat-omniquant-w3a16g128asym-cuda.so\")"
+        "cm = ChatModule(model=\"dist/Llama-2-7b-chat-omniquant-w3a16g128asym/params\", model_lib_path=\"dist/Llama-2-7b-chat-omniquant-w3a16g128asym/Llama-2-7b-chat-omniquant-w3a16g128asym-cuda.so\")"
       ]
     },
     {


### PR DESCRIPTION
Fixes changes to mlc-chat module based on the PR : https://github.com/mlc-ai/mlc-llm/issues/1080 , which changed `lib_path` argument to `model_lib_path`