### PR TITLE
Enforce minimum CLIPMIN value for the scale.

### DIFF
--- a/quantize/quantizer.py
+++ b/quantize/quantizer.py
@@ -142,7 +142,6 @@ class UniformAffineQuantizer(nn.Module):
             range = xmax - xmin
             scale = range / (2**self.n_bits-1)
             self.scale = scale.clamp(min=CLIPMIN, max=1e4)
-            self.scale = scale
             zero_point = -(xmin) / (self.scale)
         self.round_zero_point = zero_point.clamp(min=-1e4, max=1e4).round()
         


### PR DESCRIPTION
This is minor, but it causes `nan` values in my experiments.

As far as I understand, the `CLIPMIN` bound in `quantizer.py` is introduced to prevent the scale from being too small and causing division by zero. However, after the scale is clamped in the right range, it is immediately set back to the original value. In the current implementation, it makes the most sense to remove line 146 and just set `CLIPMIN` to 0 if that is desired in any given case.

#31 might also be related.