### PR TITLE
Bugfix/attention mask and implementation

### DIFF
--- a/main.py
+++ b/main.py
@@ -222,6 +222,12 @@ def main():
     parser.add_argument("--limit", type=int, default=-1)
     parser.add_argument("--multigpu", action="store_true", help="at eval, map model to multiple gpus")
     parser.add_argument("--deactive_amp", action="store_true", help="deactivate AMP when 8<=bits<16")
+    parser.add_argument(
+        "--attn_implementation",
+        type=str, required=False, default="eager",
+        choices=["eager", "sdpa", "flash_attention_2"],
+        help="attention implementation that the model works with",
+    )
     parser.add_argument("--net", type=str, default=None, choices=net_choices)
     parser.add_argument("--act-scales", type=str, default=None)
     parser.add_argument("--act-shifts", type=str, default=None)

--- a/models/LMClass.py
+++ b/models/LMClass.py
@@ -21,6 +21,16 @@ class LMClass(BaseLM):
 
         self.model_config = args.model
         config = AutoConfig.from_pretrained(args.model)
+
+        if getattr(config, '_attn_implementation_internal', None) is None:
+            print(
+                "Model's config file does not contain info about attention implementation (no `attn_implementation` attribute)."
+                " We are going to assume that the model uses \"eager\" attention."
+                " If this is not true, please specify the correct attention in the model's config file."
+            )
+
+            config._attn_implementation_internal = 'eager'
+
         self.tokenizer = AutoTokenizer.from_pretrained(args.model, use_fast=False,legacy=False)
         # self.model = AutoModelForCausalLM.from_pretrained(args.model, config=config, device_map='cpu',torch_dtype=config.torch_dtype)
         self.model = AutoModelForCausalLM.from_pretrained(args.model, config=config, device_map='cpu',torch_dtype=torch.float16)

--- a/models/LMClass.py
+++ b/models/LMClass.py
@@ -20,16 +20,9 @@ class LMClass(BaseLM):
         self.batch_size_per_gpu = args.batch_size
 
         self.model_config = args.model
-        config = AutoConfig.from_pretrained(args.model)
-
-        if getattr(config, '_attn_implementation_internal', None) is None:
-            print(
-                "Model's config file does not contain info about attention implementation (no `attn_implementation` attribute)."
-                " We are going to assume that the model uses \"eager\" attention."
-                " If this is not true, please specify the correct attention in the model's config file."
-            )
-
-            config._attn_implementation_internal = 'eager'
+        config = AutoConfig.from_pretrained(
+            args.model, attn_implementation=args.attn_implementation
+        )
 
         self.tokenizer = AutoTokenizer.from_pretrained(args.model, use_fast=False,legacy=False)
         # self.model = AutoModelForCausalLM.from_pretrained(args.model, config=config, device_map='cpu',torch_dtype=config.torch_dtype)

--- a/quantize/omniquant.py
+++ b/quantize/omniquant.py
@@ -161,7 +161,16 @@ def omniquant(
     fp_inps_2 = copy.deepcopy(inps) if args.aug_loss else None # take output of quantization model as input
     
     attention_mask = cache["attention_mask"]
-    attention_mask_batch = attention_mask.repeat(args.batch_size,1,1,1) if args.deactive_amp else attention_mask.repeat(args.batch_size,1,1,1).float()
+
+    if attention_mask is not None:
+        attention_mask_batch = attention_mask.repeat(args.batch_size,1,1,1) if args.deactive_amp else attention_mask.repeat(args.batch_size,1,1,1).float()
+    else:
+        logger.info(
+            "No attention mask caught from the first layer."
+            " Seems that model's attention works without a mask."
+        )
+        attention_mask_batch = None
+
     loss_func = torch.nn.MSELoss()
     if is_llama:
         position_ids = cache["position_ids"]


### PR DESCRIPTION
Issue: https://github.com/OpenGVLab/OmniQuant/issues/46

I had to change attn implementation initialization. Unexpectedly (at least for me :sweat_smile:), it turned out that it is not possible to specify attention in the model's config.json file. One can only set it as an argument when creating an object (`attn_implementation` is taken from "kwargs", not "config_dict", see: https://github.com/huggingface/transformers/blob/v4.36.1/src/transformers/configuration_utils.py#L772). So, I add attention to args and give it to `config` object when it is created.

I hope that this change is OK (new argument to parser + modified `AutoConfig.from_pretrained` call).