### PR TITLE
[quantizer] add Odyssey-style symmetric quantization

### DIFF
--- a/main.py
+++ b/main.py
@@ -217,6 +217,7 @@ def main():
     parser.add_argument("--lwc",default=False, action="store_true",help="activate learnable weight clipping")
     parser.add_argument("--aug_loss", default=False, action="store_true", help="calculate additional loss with same input")
     parser.add_argument("--symmetric",default=False, action="store_true", help="symmetric quantization")
+    parser.add_argument("--disable_zero_point",default=False, action="store_true", help="quantization without zero_point")
     parser.add_argument("--a_dynamic_method", type=str, default="per_token", choices=["per_token"])
     parser.add_argument("--w_dynamic_method", type=str, default="per_channel", choices=["per_channel"])
     parser.add_argument("--limit", type=int, default=-1)
@@ -275,7 +276,8 @@ def main():
         "symmetric": args.symmetric,
         "dynamic_method": args.w_dynamic_method,
         "group_size": args.group_size,
-        "lwc":args.lwc
+        "lwc":args.lwc,
+        "disable_zero_point": args.disable_zero_point
     }
     args.act_quant_params = {
         "n_bits":  args.abits,


### PR DESCRIPTION
## What does this PR do?

Implement an OdysseyLLM-style symmetric quantization which disables the zero_point, offering greater **hardware efficiency** compared to the current version.

ref: https://arxiv.org/pdf/2311.09550v1.pdf

current version:
![image](https://github.com/OpenGVLab/OmniQuant/assets/13466943/fdbde5fc-fb62-41ed-8ec3-998108417808)


Odyssey version:
![image](https://github.com/OpenGVLab/OmniQuant/assets/13466943/2b5dc020-1b83-4d27-8462-573b83a355ee)


## Benchmark (W4A8, W per-channel, A per-token)

| calibration dataset             | PPL (wiki2)   | PPL (ptb) | PPL (c4) | additional args |
|---------------------------|-------|----|-----|---|
| NONE (fp16) | 7.076 | 28.138 | - | - |
| wiki2         | 7.456  | 51.077 | - | - |
| ptb         | 7.638  | 30.797 | 9.648 | - |
| mix (wiki2 + ptb + c4)         | 7.485  | 33.096 | 9.487 | - |
| mix (wiki2 + ptb + c4)    | 7.575  | 33.673 | 9.550 | --symmetric |
| mix (wiki2 + ptb + c4)       | 7.577  | 32.644 | 9.522 | --symmetric --disable_zero_point |

## Reproduce

```sh
# https://github.com/OpenGVLab/OmniQuant/issues/37
CUDA_VISIBLE_DEVICES=0 python main.py \
  --model /jfs-hdfs/user/xingchen.song/share/LLM/Llama-2-7b-chat --eval_ppl \
  --epochs 60 --output_dir ./log/Llama-2-7b-chat-w4a8-ep60-mix-sym-odyssey \
  --wbits 4 --abits 8 --lwc --aug_loss --deactive_amp \
  --let --let_lr 1e-3 --alpha 0.75 \
  --calib_dataset mix --symmetric --disable_zero_point
```